### PR TITLE
<보안> JWT 검증 (JwtAuthenticationFilter) 기능 구현  

### DIFF
--- a/src/main/java/com/sparta/delivery/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/delivery/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.sparta.delivery.config;
 
 
+import com.sparta.delivery.config.jwt.JwtAuthenticationFilter;
+import com.sparta.delivery.config.jwt.JwtUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -9,10 +11,17 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+
+    public SecurityConfig(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -22,6 +31,8 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable());
+
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
         http.sessionManagement((sessionManagement) ->
                 sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/src/main/java/com/sparta/delivery/config/auth/PrincipalDetails.java
+++ b/src/main/java/com/sparta/delivery/config/auth/PrincipalDetails.java
@@ -1,0 +1,34 @@
+package com.sparta.delivery.config.auth;
+
+import com.sparta.delivery.domain.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class PrincipalDetails implements UserDetails {
+
+    private final User user;
+
+    public PrincipalDetails(User user) {
+        super();
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(user.getRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+}

--- a/src/main/java/com/sparta/delivery/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/delivery/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,127 @@
+package com.sparta.delivery.config.jwt;
+
+import com.sparta.delivery.config.auth.PrincipalDetails;
+import com.sparta.delivery.domain.user.entity.User;
+import com.sparta.delivery.domain.user.enums.UserRoles;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+
+/**
+ * 모든 Http 요청에서 JWT 토큰을 추철하고 사용자 인증을 처리하는 필터
+ *
+ * 1. 요청 헤더에서 JWT 토큰을 추출해 인즈 정보 설정
+ * 2. 인증되지 않은 요청인 특정 URL은 필터 통과
+ * 3. JWT 만료, 형식 오류, 서명 오류 등을 처리하고, 예외처리 코드와 메시지 반환
+ *
+ *
+ * 특정 ULR (회원가입, 로그인 , 스웨거)은 필터에서 제외 (추후 권한 설정시 수정할듯)
+ */
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    // Header key 식별값
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    // Token 식별자
+    public static final String BEARER_PREFIX = "Bearer ";
+
+
+    // 검사에서 제외할 경로
+    private static final List<String> excludeUrls = List.of(
+            "/api/user/signup",
+            "/api/user/signin",
+            "/swagger-ui/**",
+            "/v3/api-docs/**"
+    );
+
+    // 특정 URL이 해당하면 필터링을 저적용하지않도록 검사
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String requestPath = request.getRequestURI();
+        return excludeUrls.stream().anyMatch(url -> pathMatcher.match(url, requestPath));
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        if (shouldNotFilter(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String headerAuthorizationToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (headerAuthorizationToken == null | !headerAuthorizationToken.startsWith(BEARER_PREFIX)){
+            filterChain.doFilter(request,response);
+        }
+
+        String accessToken = headerAuthorizationToken.split(" ")[1];
+
+        try {
+            jwtUtil.isExpired(accessToken);
+
+            String username = jwtUtil.getUsername(accessToken);
+            String email = jwtUtil.getEmail(accessToken);
+            String role = jwtUtil.getRole(accessToken);
+
+            User user = User.builder()
+                    .username(username)
+                    .email(email)
+                    .role(UserRoles.fromString(role))
+                    .build();
+
+            // 인증 사용자 정보 생성
+            PrincipalDetails principalDetails = new PrincipalDetails(user);
+
+            // 스프링 시큐리티 인증 토큰 생성
+            Authentication authentication = new UsernamePasswordAuthenticationToken(principalDetails,
+                    null,
+                    principalDetails.getAuthorities());
+
+            // 인증 정보 설정
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (ExpiredJwtException e) {
+            PrintWriter writer = response.getWriter();
+            writer.print("Access token expired");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        } catch (MalformedJwtException e) {
+            PrintWriter writer = response.getWriter();
+            writer.print("Malformed JWT token");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST); // 400 Bad Request
+            return;
+        } catch (JwtException e) {
+            PrintWriter writer = response.getWriter();
+            writer.print("Invalid token claims");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST); // 400 Bad Request
+            return;
+        }   catch (Exception e) {
+            PrintWriter writer = response.getWriter();
+            writer.print("Error processing JWT token");
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR); // 500 Internal Server Error
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/sparta/delivery/domain/user/enums/UserRoles.java
+++ b/src/main/java/com/sparta/delivery/domain/user/enums/UserRoles.java
@@ -1,6 +1,8 @@
 package com.sparta.delivery.domain.user.enums;
 
 
+import java.util.Arrays;
+
 public enum UserRoles {
     ROLE_CUSTOMER("ROLE_CUSTOMER"),  // 일반 사용자 (고객)
     ROLE_OWNER("ROLE_OWNER"),        // 자원을 소유한 사용자
@@ -12,5 +14,13 @@ public enum UserRoles {
     // 생성자
     UserRoles(String role) {
         this.role = role;
+    }
+
+    // String을 받아 Enum 값으로 변환하는 정적 메서드
+    public static UserRoles fromString(String role) {
+        return Arrays.stream(UserRoles.values())
+                .filter(userRole -> userRole.role.equals(role))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 역할: " + role));
     }
 }


### PR DESCRIPTION
- 모든 HTTP 요청에 대한 권한 jwt 토큰 검증 필터 구현
- 요청 헤더에서 JWT 토큰을 추출하여 사용자 인증 처리
- JWT 만료, 형식 오류, 서명 오류 등 예외처리
- 회원가입, 로그인, Swagger 관련 URL 필터 제외
- 유효한 JWT 토큰이면 인증된 사용자로 설정해 SecurityContext 에 인증 정보 저장


`
.requestMatchers("특정 권한만 접근 가능한 경로").hasAnyRole("ROLE_제외 한 권한") // 예) ROLE_CUSTOMER -> CUSTOMER
`