### PR TITLE
feat : User 단일 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.sparta.delivery.config.global.exception;
 
 import com.sparta.delivery.config.global.exception.custom.ForbiddenException;
+import com.sparta.delivery.config.global.exception.custom.UserNotFoundException;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -27,6 +28,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ExceptionResponse> forbiddenException(ForbiddenException ex){
         int status = HttpServletResponse.SC_FORBIDDEN;
         ExceptionResponse response = new ExceptionResponse("FORBIDDEN", ex.getMessage(), status);
+        return ResponseEntity.status(status).body(response);
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> userNotFoundException(UserNotFoundException ex){
+        int status = HttpServletResponse.SC_NOT_FOUND;
+        ExceptionResponse response = new ExceptionResponse("User_Not_Found", ex.getMessage(), status);
         return ResponseEntity.status(status).body(response);
     }
 

--- a/src/main/java/com/sparta/delivery/config/global/exception/custom/UserNotFoundException.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/custom/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.config.global.exception.custom;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/delivery/domain/user/controller/UserController.java
@@ -8,13 +8,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/user")
@@ -45,6 +43,12 @@ public class UserController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(userService.authenticateUser(loginRequestDto));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getUserDetail(@PathVariable("id")UUID id){
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(userService.getUserDetail(id));
     }
 
     private Map<String, Object> ValidationErrorResponse(BindingResult bindingResult) {

--- a/src/main/java/com/sparta/delivery/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/delivery/domain/user/repository/UserRepository.java
@@ -9,6 +9,11 @@ import java.util.UUID;
 public interface UserRepository extends JpaRepository<User , UUID> {
 
     Optional<User> findByUsername(String username);
+
+    // username 존재 유무 확인 (존재 : true , 없을 시 : false)
     boolean existsByUsername(String username);
+
+    // 삭제되지 않은 유저 단일 조회
+    Optional<User> findByUserIdAndDeletedAtIsNull(UUID id);
 
 }

--- a/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.sparta.delivery.domain.user.service;
 
+import com.sparta.delivery.config.global.exception.custom.UserNotFoundException;
 import com.sparta.delivery.config.jwt.JwtUtil;
 import com.sparta.delivery.domain.user.dto.JwtResponseDto;
 import com.sparta.delivery.domain.user.dto.LoginRequestDto;
@@ -9,9 +10,11 @@ import com.sparta.delivery.domain.user.entity.User;
 import com.sparta.delivery.domain.user.enums.UserRoles;
 import com.sparta.delivery.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -54,5 +57,14 @@ public class UserService {
         String accessToken = jwtUtil.createJwt(user.getUsername(), user.getEmail(), user.getRole());
 
         return new JwtResponseDto(accessToken);
+    }
+
+    public UserResDto getUserDetail(UUID id) {
+
+        User user = userRepository.findByUserIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new UserNotFoundException("User Not Found By Id : " + id));
+
+        return user.toResponseDto();
+
     }
 }


### PR DESCRIPTION
- /api/user/{id} 경로의 GET 요청을 처리
- UserNotFoundException.java 커스텀 예외처리 구현 404(not found) 반환
- UserRepository 삭제되지 않은 단일 유저 조회 구현
  - findByUserIdAndDeletedAtIsNull