### PR TITLE
feat: User 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/delivery/config/jwt/JwtAuthenticationFilter.java
@@ -71,7 +71,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String headerAuthorizationToken = request.getHeader(AUTHORIZATION_HEADER);
 
-        if (headerAuthorizationToken == null | !headerAuthorizationToken.startsWith(BEARER_PREFIX)){
+        if (headerAuthorizationToken == null || !headerAuthorizationToken.startsWith(BEARER_PREFIX)){
             filterChain.doFilter(request,response);
         }
 

--- a/src/main/java/com/sparta/delivery/domain/common/Timestamped.java
+++ b/src/main/java/com/sparta/delivery/domain/common/Timestamped.java
@@ -7,6 +7,9 @@ import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
 
@@ -43,4 +46,38 @@ public abstract class Timestamped {
     // 레코드 삭제 사용자
     @Column
     private String deletedBy;
+
+    // 생성 전 실행되는 로직
+    @PrePersist
+    protected void onCreate() {
+        String currentUser = getCurrentUser(); // 현재 사용자 가져오기
+        this.createdBy = currentUser;
+        this.updatedBy = currentUser; // 생성 시 updatedBy도 같이 설정
+    }
+
+    // 업데이트 전 실행되는 로직
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedBy = getCurrentUser(); // 업데이트 시 사용자 변경
+    }
+
+    // 현재 검증된 사용자 username을 가져오는 로직
+    private String getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object principal = authentication.getPrincipal();
+
+            if (principal instanceof UserDetails) {
+
+                return ((UserDetails) principal).getUsername(); // 현재 로그인한 사용자의 username 반환
+            } else {
+
+                // 인증되지않은 사용자는 Security에서 anonymousUser 로 처리해 유저 createAt 이 anonymousUser 로 들어가
+                // 2NE1 으로 설정
+                return "2NE1";
+            }
+        }
+        return "system"; // 기본값 (비로그인 상태)
+    }
 }

--- a/src/main/java/com/sparta/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/delivery/domain/user/controller/UserController.java
@@ -5,6 +5,9 @@ import com.sparta.delivery.domain.user.dto.SignupReqDto;
 import com.sparta.delivery.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -46,9 +49,16 @@ public class UserController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<?> getUserDetail(@PathVariable("id")UUID id){
+    public ResponseEntity<?> getUserById(@PathVariable("id")UUID id){
         return ResponseEntity.status(HttpStatus.OK)
-                .body(userService.getUserDetail(id));
+                .body(userService.getUserById(id));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getUsers(@PageableDefault(size = 10, page = 0, sort = "createdAt", direction = Sort.Direction.DESC)
+                                      Pageable pageable){
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(userService.getUsers(pageable));
     }
 
     private Map<String, Object> ValidationErrorResponse(BindingResult bindingResult) {

--- a/src/main/java/com/sparta/delivery/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/delivery/domain/user/entity/User.java
@@ -48,8 +48,8 @@ public class User extends Timestamped {
 
         return new UserResDto(
                 this.userId,
-                this.email,
                 this.username,
+                this.email,
                 this.nickname,
                 this.role.name()
         );

--- a/src/main/java/com/sparta/delivery/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/delivery/domain/user/repository/UserRepository.java
@@ -1,7 +1,10 @@
 package com.sparta.delivery.domain.user.repository;
 
 import com.sparta.delivery.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -16,4 +19,7 @@ public interface UserRepository extends JpaRepository<User , UUID> {
     // 삭제되지 않은 유저 단일 조회
     Optional<User> findByUserIdAndDeletedAtIsNull(UUID id);
 
+    // 삭제되지 않은 유저 페이징 조회 (생성일 최근일 부터 정렬)
+    @Query("SELECT u FROM User u WHERE u.deletedAt IS NULL ORDER BY u.createdAt DESC")
+    Page<User> findAllDeletedIsNull(Pageable pageable);
 }

--- a/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
@@ -11,13 +11,17 @@ import com.sparta.delivery.domain.user.enums.UserRoles;
 import com.sparta.delivery.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserService {
 
     private final UserRepository userRepository;
@@ -59,12 +63,27 @@ public class UserService {
         return new JwtResponseDto(accessToken);
     }
 
-    public UserResDto getUserDetail(UUID id) {
+    @Transactional(readOnly = true)
+    public UserResDto getUserById(UUID id) {
 
         User user = userRepository.findByUserIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new UserNotFoundException("User Not Found By Id : " + id));
 
         return user.toResponseDto();
+    }
 
+    @Transactional(readOnly = true)
+    public Page<UserResDto> getUsers(Pageable pageable) {
+        // Pageable 로받아오면 자동으로 페이지 번호(page) 와 size 가 음수 값으로 들어와도
+        // page = 0 , size = 10 으로 기본값으로 처리 해준다.
+
+        Page<User> userPage = userRepository.findAllDeletedIsNull(pageable);
+
+        if (userPage.isEmpty()){
+            throw new UserNotFoundException("Users Not Found");
+        }
+
+        // Page<User> -> Page<UserResDto>
+        return userPage.map(User::toResponseDto);
     }
 }

--- a/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
@@ -44,8 +44,6 @@ public class UserService {
         // 권한은 관리자 검증 후 관리자가 권한을 변경하는 방법으로 하겠습니다.
         // 최초의 MASTER 는 DB에서 직접 설정
 
-        user.setCreatedBy(user.getEmail());
-
         return userRepository.save(user).toResponseDto();
     }
 

--- a/src/test/java/com/sparta/delivery/userTest/UserServiceTest.java
+++ b/src/test/java/com/sparta/delivery/userTest/UserServiceTest.java
@@ -92,7 +92,7 @@ public class UserServiceTest {
 
         // When & Then
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> userService.signup(signupReqDto));
-        assertEquals("username already exists : testuser", exception.getMessage());
+        assertEquals("username already exists : test@example.com", exception.getMessage());
     }
 
     @Test

--- a/src/test/java/com/sparta/delivery/userTest/UserServiceTest.java
+++ b/src/test/java/com/sparta/delivery/userTest/UserServiceTest.java
@@ -1,0 +1,189 @@
+package com.sparta.delivery.userTest;
+
+
+import com.sparta.delivery.config.global.exception.custom.UserNotFoundException;
+import com.sparta.delivery.config.jwt.JwtUtil;
+import com.sparta.delivery.domain.user.dto.*;
+import com.sparta.delivery.domain.user.entity.User;
+import com.sparta.delivery.domain.user.enums.UserRoles;
+import com.sparta.delivery.domain.user.repository.UserRepository;
+import com.sparta.delivery.domain.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    private User testUser;
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        // 테스트용 사용자 생성
+        userId = UUID.randomUUID();
+        testUser = User.builder()
+                .userId(userId)
+                .email("test@example.com")
+                .password("encodedPassword")
+                .username("testuser")
+                .nickname("testnick")
+                .role(UserRoles.ROLE_CUSTOMER)
+                .build();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 테스트")
+    void testSignupSuccess() {
+        // Given
+        SignupReqDto signupReqDto = new SignupReqDto("test@example.com", "testuser", "password", "testnick");
+
+        when(userRepository.existsByUsername("testuser")).thenReturn(false); // 해당 username 존재 유무 확인
+        when(passwordEncoder.encode("password")).thenReturn("encodedPassword"); // 비밀번호 엄호화
+        when(userRepository.save(any(User.class))).thenReturn(testUser); // user entity 에 저장
+
+        // When
+        UserResDto result = userService.signup(signupReqDto);
+
+        // Then
+        assertNotNull(result); // result 가 null 인지 검사
+        assertEquals("test@example.com", result.getEmail()); // null 이 아닌경우 예상한 값과 email이 동일한지 검사
+        assertEquals("testuser", result.getUsername()); // null 아닌 경우 예상한 값과 username이 동일한지 검사
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 테스트")
+    void testSignupFail(){
+        // Given
+        SignupReqDto signupReqDto = new SignupReqDto("test@example.com", "testuser", "password", "testnick");
+
+
+        // any() 권장
+        when(userRepository.existsByUsername(any())).thenReturn(true);
+
+        // When & Then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> userService.signup(signupReqDto));
+        assertEquals("username already exists : testuser", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("로그인 성공 테스트")
+    void testAuthenticateUserSuccess() {
+        // Given
+        LoginRequestDto loginRequestDto = new LoginRequestDto("testuser", "password");
+
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.matches("password", testUser.getPassword())).thenReturn(true);
+        when(jwtUtil.createJwt(anyString(), anyString(), any(UserRoles.class))).thenReturn("accessToken");
+
+        // When
+        JwtResponseDto response = userService.authenticateUser(loginRequestDto);
+
+        // Then
+        assertNotNull(response);
+        assertEquals("accessToken", response.getAccessToken());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 잘못된 비밀번호")
+    void testAuthenticateUserFailPassword() {
+        // Given
+        LoginRequestDto loginRequestDto = new LoginRequestDto("testuser", "1234");
+
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.matches("1234", testUser.getPassword())).thenReturn(false);
+
+        // When & Then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> userService.authenticateUser(loginRequestDto));
+        assertEquals("Invalid password : wrongpassword", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("유저 단일 조회 성공")
+    void testGetUserByIdSuccess() {
+        // Given
+        when(userRepository.findByUserIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(testUser));
+
+        // When
+        UserResDto result = userService.getUserById(userId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(testUser.getEmail(), result.getEmail());
+    }
+
+    @Test
+    @DisplayName("유저 단일 조회 실패 - 존재하지않는 ID(UUID)")
+    void testGetUserByIdFail(){
+        // Given
+        when(userRepository.findByUserIdAndDeletedAtIsNull(userId)).thenReturn(Optional.empty());
+
+
+        // When Then
+        UserNotFoundException exception = assertThrows(UserNotFoundException.class, () -> userService.getUserById(userId));
+        assertEquals("User Not Found By Id : " + userId, exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("모든유저 조회 성공")
+    void testGetUsersSuccess(){
+
+        // Given
+        PageRequest pageable = PageRequest.of(0,10);
+        Page<User> userPage = new PageImpl<>(List.of(testUser));
+
+        when(userRepository.findAllDeletedIsNull(pageable)).thenReturn(userPage);
+
+        // When
+        Page<UserResDto> result = userService.getUsers(pageable);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.getTotalElements());
+
+    }
+
+    @Test
+    @DisplayName("모든 유저 조회 실패 - 결과 없음")
+    void testGetUsersFail(){
+        // Given
+        PageRequest pageable = PageRequest.of(0,10);
+        Page<User> emptyPage = Page.empty();
+
+        when(userRepository.findAllDeletedIsNull(pageable)).thenReturn(emptyPage);
+
+        // When & Then
+        UserNotFoundException userNotFoundException = assertThrows(UserNotFoundException.class , ()-> userService.getUsers(pageable));
+        assertEquals("Users Not Found", userNotFoundException.getMessage());
+    }
+
+}


### PR DESCRIPTION
- /api/user 경로의 GET 요청 처리
- size, page 파라미터를 받아 페이징된 리스트 반환
- Timestamped 클래스에 createdBy, updatedBy 자동화 처리 추가
- JwtAuthenticationFilter: 74번 라인 오타 수정
- UserTest: 회원가입, 로그인, 단일 조회, 리스트 조회에 대한 테스트 코드 작성