### PR TITLE
<유저> update 기능 구현 

### DIFF
--- a/src/main/java/com/sparta/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/delivery/domain/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.sparta.delivery.domain.user.controller;
 
+import com.sparta.delivery.config.auth.PrincipalDetails;
 import com.sparta.delivery.domain.user.dto.LoginRequestDto;
 import com.sparta.delivery.domain.user.dto.SignupReqDto;
+import com.sparta.delivery.domain.user.dto.UserUpdateReqDto;
 import com.sparta.delivery.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +12,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
@@ -59,6 +62,21 @@ public class UserController {
                                       Pageable pageable){
         return ResponseEntity.status(HttpStatus.OK)
                 .body(userService.getUsers(pageable));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateUser(@PathVariable("id") UUID id,
+                                        @AuthenticationPrincipal PrincipalDetails principalDetails,
+                                        @RequestBody UserUpdateReqDto userUpdateReqDto,
+                                        BindingResult bindingResult){
+
+        if (bindingResult.hasErrors()){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ValidationErrorResponse(bindingResult));
+        }
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(userService.updateUser(id, principalDetails, userUpdateReqDto));
     }
 
     private Map<String, Object> ValidationErrorResponse(BindingResult bindingResult) {

--- a/src/main/java/com/sparta/delivery/domain/user/dto/UserUpdateReqDto.java
+++ b/src/main/java/com/sparta/delivery/domain/user/dto/UserUpdateReqDto.java
@@ -1,0 +1,34 @@
+package com.sparta.delivery.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserUpdateReqDto {
+
+    // 현재 비밀번호 (기존 비밀번호 확인용)
+    @NotBlank(message = "Current password is required")
+    private String currentPassword;
+
+    // 비밀번호 검증 (8~15자, 대소문자, 숫자, 특수문자 포함)
+    @NotBlank(message = "Password is required")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$",
+            message = "Invalid password format: 최소 8자 이상, 15자 이하이며 대소문자, 숫자, 특수문자가 포함되어야 합니다.")
+    private String newPassword;
+
+    // 이메일 검증
+    @NotBlank(message = "Email is required")
+    @Email(message = "Invalid email format")
+    private String email;
+
+    // 닉네임
+    @NotBlank(message = "nickname is required")
+    private String nickname;
+
+}

--- a/src/main/java/com/sparta/delivery/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/delivery/domain/user/entity/User.java
@@ -5,10 +5,7 @@ import com.sparta.delivery.domain.delivery_address.entity.DeliveryAddress;
 import com.sparta.delivery.domain.user.dto.UserResDto;
 import com.sparta.delivery.domain.user.enums.UserRoles;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.UUID;
 import java.util.ArrayList;
@@ -16,6 +13,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/sparta/delivery/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/delivery/domain/user/entity/User.java
@@ -13,8 +13,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Setter
-@Builder
+@Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "p_user")

--- a/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
@@ -88,7 +88,7 @@ public class UserService {
         User user = userRepository.findByUserIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new UserNotFoundException("User Not Found By Id : " + id));
 
-        if (!user.getUsername().equals(principalDetails.getUsername()) || !principalDetails.getRole().name().equals("ROLE_MASTER")){
+        if (!user.getUsername().equals(principalDetails.getUsername()) && !principalDetails.getRole().name().equals("ROLE_MASTER")){
             throw new ForbiddenException("Access denied.");
         }
 
@@ -96,11 +96,12 @@ public class UserService {
             throw new ForbiddenException("Incorrect password.");
         }
 
-        user.setPassword(passwordEncoder.encode(userUpdateReqDto.getNewPassword()));
-        user.setEmail(userUpdateReqDto.getEmail());
-        user.setNickname(userUpdateReqDto.getNickname());
-        user.setRole(UserRoles.ROLE_CUSTOMER);
+        User updateUser = user.toBuilder()
+                .password(passwordEncoder.encode(userUpdateReqDto.getNewPassword()))
+                .email(userUpdateReqDto.getEmail())
+                .nickname(userUpdateReqDto.getNickname())
+                .build();
 
-        return userRepository.save(user).toResponseDto();
+        return userRepository.save(updateUser).toResponseDto();
     }
 }

--- a/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
@@ -88,7 +88,7 @@ public class UserService {
         User user = userRepository.findByUserIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new UserNotFoundException("User Not Found By Id : " + id));
 
-        if (!user.getUsername().equals(principalDetails.getUsername())){
+        if (!user.getUsername().equals(principalDetails.getUsername()) || !principalDetails.getRole().name().equals("ROLE_MASTER")){
             throw new ForbiddenException("Access denied.");
         }
 


### PR DESCRIPTION
- /api/user/{id} 경로의 PUT 요청 처리
- @AuthenticationPrincipal을 사용하여 작성자 확인
- username 및 role을 제외한 필드만 수정 가능하도록 구현
- update 기능에 대한 테스트 코드 작성 완료
- ROLE_MASTER는 유저의 정보를 수정할 수 있다.
