### PR TITLE
<유저> 사용자 role 변경 기능 구현 

### DIFF
--- a/src/main/java/com/sparta/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/delivery/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.sparta.delivery.domain.user.controller;
 import com.sparta.delivery.config.auth.PrincipalDetails;
 import com.sparta.delivery.domain.user.dto.LoginRequestDto;
 import com.sparta.delivery.domain.user.dto.SignupReqDto;
+import com.sparta.delivery.domain.user.dto.UserRoleUpdateReqDto;
 import com.sparta.delivery.domain.user.dto.UserUpdateReqDto;
 import com.sparta.delivery.domain.user.service.UserService;
 import jakarta.validation.Valid;
@@ -64,10 +65,10 @@ public class UserController {
                 .body(userService.getUsers(pageable));
     }
 
-    @PutMapping("/{id}")
+    @PatchMapping("/{id}")
     public ResponseEntity<?> updateUser(@PathVariable("id") UUID id,
                                         @AuthenticationPrincipal PrincipalDetails principalDetails,
-                                        @RequestBody UserUpdateReqDto userUpdateReqDto,
+                                        @RequestBody @Valid UserUpdateReqDto userUpdateReqDto,
                                         BindingResult bindingResult){
 
         if (bindingResult.hasErrors()){
@@ -77,6 +78,21 @@ public class UserController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(userService.updateUser(id, principalDetails, userUpdateReqDto));
+    }
+
+    @PatchMapping("/{id}/role")
+    public ResponseEntity<?> updateRole(@PathVariable("id") UUID id,
+                                        @AuthenticationPrincipal PrincipalDetails principalDetails,
+                                        @RequestBody @Valid UserRoleUpdateReqDto userRoleUpdateReqDto,
+                                        BindingResult bindingResult){
+
+        if (bindingResult.hasErrors()){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ValidationErrorResponse(bindingResult));
+        }
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(userService.updateRole(id, principalDetails, userRoleUpdateReqDto));
     }
 
     private Map<String, Object> ValidationErrorResponse(BindingResult bindingResult) {

--- a/src/main/java/com/sparta/delivery/domain/user/dto/UserRoleUpdateReqDto.java
+++ b/src/main/java/com/sparta/delivery/domain/user/dto/UserRoleUpdateReqDto.java
@@ -1,0 +1,16 @@
+package com.sparta.delivery.domain.user.dto;
+
+import com.sparta.delivery.domain.user.enums.UserRoles;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserRoleUpdateReqDto {
+
+    @NotNull(message = "Role 값은 필수입니다.")
+    private UserRoles role;
+}

--- a/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
@@ -104,4 +104,19 @@ public class UserService {
 
         return userRepository.save(updateUser).toResponseDto();
     }
+
+    public UserResDto updateRole(UUID id, PrincipalDetails principalDetails, UserRoleUpdateReqDto userRoleUpdateReqDto) {
+        if (!principalDetails.getRole().name().equals("ROLE_MASTER")){
+            throw new ForbiddenException("Access denied.");
+        }
+
+        User user = userRepository.findByUserIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new UserNotFoundException("User Not Found By Id : " + id));
+
+        User updateUser = user.toBuilder()
+                .role(userRoleUpdateReqDto.getRole())
+                .build();
+
+        return userRepository.save(updateUser).toResponseDto();
+    }
 }


### PR DESCRIPTION
- /api/user/{id}/role 경로에 대한 PATCH 요청 처리
- @AuthenticationPrincipal로 마스터 계정인지 검사
- UserRoleUpdateReqDto 구현 및 적용
- UserRoles 타입을 사용해 role 업데이트
- 모든 PUT 요청을 PATCH로 변경


- 정해진 역할을 프론트에서 문자열로 전송하면 스프링에서 자동으로 enum으로 매핑해줌