### PR TITLE
<유저> 사용자 delete 기능 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/delivery/domain/user/controller/UserController.java
@@ -95,6 +95,16 @@ public class UserController {
                 .body(userService.updateRole(id, principalDetails, userRoleUpdateReqDto));
     }
 
+    @PatchMapping("/{id}/delete")
+    public ResponseEntity<?> deleteUser(@PathVariable("id") UUID id,
+                                        @AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        userService.deleteUser(id, principalDetails);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .build();
+    }
+
     private Map<String, Object> ValidationErrorResponse(BindingResult bindingResult) {
         List<Map<String, String>> errors = bindingResult.getFieldErrors().stream()
                 .map(fieldError -> Map.of(

--- a/src/main/java/com/sparta/delivery/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/delivery/domain/user/repository/UserRepository.java
@@ -19,6 +19,9 @@ public interface UserRepository extends JpaRepository<User , UUID> {
     // 삭제되지 않은 유저 단일 조회
     Optional<User> findByUserIdAndDeletedAtIsNull(UUID id);
 
+    // 삭제되지 않은 유저 단일 조회 (username)
+    Optional<User> findByUsernameAndDeletedAtIsNull(String username);
+
     // 삭제되지 않은 유저 페이징 조회 (생성일 최근일 부터 정렬)
     @Query("SELECT u FROM User u WHERE u.deletedAt IS NULL ORDER BY u.createdAt DESC")
     Page<User> findAllDeletedIsNull(Pageable pageable);

--- a/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.UUID;
 
 @Service


### PR DESCRIPTION
- /api/user/{id}/delete 경로에 대한 PATCH 요청 처리
- @AuthenticationPrincipal을 사용한 권한 인증 (사용자 본인, 매니저, 마스터만 삭제 가능)
- UserRepository에 findByUserIdAndDeletedAtIsNull 메서드 추가
- 삭제된 사용자는 로그인 및 다른 기능을 사용할 수 없도록 처리