### PR TITLE
상품 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/domain/product/controller/ProductController.java
+++ b/src/main/java/com/sparta/delivery/domain/product/controller/ProductController.java
@@ -6,6 +6,7 @@ import com.sparta.delivery.domain.product.dto.ProductResponseDto;
 import com.sparta.delivery.domain.product.service.ProductService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,5 +25,11 @@ public class ProductController {
     public ResponseEntity<ProductResponseDto> addProductToStore(@PathVariable UUID storeId, @Valid @RequestBody ProductRequestDto productRequestDto, @AuthenticationPrincipal PrincipalDetails userDetails) {
         ProductResponseDto productResponseDto = productService.addProductToStore(storeId, productRequestDto, userDetails.getUsername());
         return ResponseEntity.status(HttpStatus.CREATED).body(productResponseDto);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<ProductResponseDto>> getAllProducts(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "10") int size, @RequestParam(defaultValue = "createdAt") String sortBy, @RequestParam(defaultValue = "desc") String order) {
+        Page<ProductResponseDto> allProducts = productService.getAllProducts(page, size, sortBy, order);
+        return ResponseEntity.ok(allProducts);
     }
 }

--- a/src/main/java/com/sparta/delivery/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/sparta/delivery/domain/product/repository/ProductRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.delivery.domain.product.repository;
 
 import com.sparta.delivery.domain.product.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
@@ -8,4 +10,6 @@ import java.util.UUID;
 public interface ProductRepository extends JpaRepository<Product, UUID> {
 
     boolean existsByNameAndStore_StoreId(String name, UUID storeId);
+
+    Page<Product> findAllByOrderByCreatedAtDescUpdatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/sparta/delivery/domain/product/service/ProductService.java
+++ b/src/main/java/com/sparta/delivery/domain/product/service/ProductService.java
@@ -6,8 +6,13 @@ import com.sparta.delivery.domain.product.dto.ProductResponseDto;
 import com.sparta.delivery.domain.product.entity.Product;
 import com.sparta.delivery.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -15,6 +20,8 @@ import java.util.UUID;
 public class ProductService {
 
     private final ProductRepository productRepository;
+    private static final List<Integer> ALLOWED_PAGE_SIZES = List.of(10, 30, 50);
+    private static final int DEFAULT_PAGE_SIZE = 10;
 
     public ProductResponseDto addProductToStore(UUID storeId, ProductRequestDto productRequestDto, String username) {
         if (productRepository.existsByNameAndStore_StoreId(productRequestDto.getName(), storeId)) {
@@ -30,5 +37,17 @@ public class ProductService {
         } catch (Exception e) {
             throw new RuntimeException("상품 등록 중 알 수 없는 오류가 발생했습니다.");
         }
+    }
+
+    public Page<ProductResponseDto> getAllProducts(int page, int size, String sortBy, String order) {
+        if (!ALLOWED_PAGE_SIZES.contains(size)) {   // 허용된 페이지 사이즈가 아닌 경우, 기본 페이지 사이즈로 설정
+            size = DEFAULT_PAGE_SIZE;
+        }
+
+        Sort.Direction direction = order.equalsIgnoreCase("asc") ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, sortBy);
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        return productRepository.findAll(pageable).map(ProductResponseDto::from);
     }
 }


### PR DESCRIPTION
### 작업 내용
- 상품 리스트 조회 기능 구현
- 정렬 기능 추가
  - 생성일순, 수정일순 중 선택하여 정렬 가능
  - 내림차순, 오름차순 중 선택하여 정렬 가능
- 페이지네이션 옵션 추가
  - 페이지 당 10건, 30건, 50건 중 선택하여 조회 가능, 이외 건수는 10건씩으로 고정