### PR TITLE
<배송지> DeliveryAddress 단일 조회 기능 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
@@ -1,11 +1,6 @@
 package com.sparta.delivery.config.global.exception;
 
-import com.sparta.delivery.config.global.exception.custom.DuplicateProductException;
-import com.sparta.delivery.config.global.exception.custom.ForbiddenException;
-import com.sparta.delivery.config.global.exception.custom.ProductNotFoundException;
-import com.sparta.delivery.config.global.exception.custom.UserNotFoundException;
-import com.sparta.delivery.config.global.exception.custom.PaymentAlreadyCompletedException;
-import com.sparta.delivery.config.global.exception.custom.ExistCardException;
+import com.sparta.delivery.config.global.exception.custom.*;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -67,6 +62,13 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ExceptionResponse> ExistCardException(ExistCardException ex){
         int status = HttpServletResponse.SC_CONFLICT;
         ExceptionResponse response = new ExceptionResponse("Already Register Card", ex.getMessage(), status);
+        return ResponseEntity.status(status).body(response);
+    }
+
+    @ExceptionHandler(DeliveryAddressNotFoundException.class)
+    public ResponseEntity<ExceptionResponse> DeliveryAddressNotFoundException(DeliveryAddressNotFoundException ex){
+        int status = HttpServletResponse.SC_NOT_FOUND;
+        ExceptionResponse response = new ExceptionResponse("DeliveryAddress Not Found", ex.getMessage(), status);
         return ResponseEntity.status(status).body(response);
     }
 

--- a/src/main/java/com/sparta/delivery/config/global/exception/custom/DeliveryAddressNotFoundException.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/custom/DeliveryAddressNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.config.global.exception.custom;
+
+public class DeliveryAddressNotFoundException extends RuntimeException {
+    public DeliveryAddressNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/delivery/domain/delivery_address/controller/DeliveryAddressController.java
+++ b/src/main/java/com/sparta/delivery/domain/delivery_address/controller/DeliveryAddressController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/delivery-addresses")
@@ -33,6 +34,13 @@ public class DeliveryAddressController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(deliveryAddressService.addAddress(addressReqDto, principalDetails));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getDeliveryAddressById(@PathVariable("id") UUID id){
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(deliveryAddressService.getDeliveryAddressById(id));
     }
 
     private Map<String, Object> ValidationErrorResponse(BindingResult bindingResult) {

--- a/src/main/java/com/sparta/delivery/domain/delivery_address/repository/DeliveryAddressRepository.java
+++ b/src/main/java/com/sparta/delivery/domain/delivery_address/repository/DeliveryAddressRepository.java
@@ -4,6 +4,7 @@ import com.sparta.delivery.domain.delivery_address.entity.DeliveryAddress;
 import com.sparta.delivery.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddress , UUID> {
@@ -13,4 +14,7 @@ public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddress
 
     // 사용자가 가지고있는 배송지 개수의 수 반환
     long countByUser(User user);
+
+    // 제거 되지않은 배송지 반환
+    Optional<DeliveryAddress> findByDeliveryAddressIdAndDeletedAtIsNull(UUID deliveryAddressId);
 }

--- a/src/main/java/com/sparta/delivery/domain/delivery_address/service/DeliveryAddressService.java
+++ b/src/main/java/com/sparta/delivery/domain/delivery_address/service/DeliveryAddressService.java
@@ -1,6 +1,7 @@
 package com.sparta.delivery.domain.delivery_address.service;
 
 import com.sparta.delivery.config.auth.PrincipalDetails;
+import com.sparta.delivery.config.global.exception.custom.DeliveryAddressNotFoundException;
 import com.sparta.delivery.domain.delivery_address.dto.AddressReqDto;
 import com.sparta.delivery.domain.delivery_address.dto.AddressResDto;
 import com.sparta.delivery.domain.delivery_address.entity.DeliveryAddress;
@@ -10,6 +11,8 @@ import com.sparta.delivery.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -46,5 +49,13 @@ public class DeliveryAddressService {
         userRepository.save(user);
 
         return deliveryAddress.toResponse();
+    }
+
+    public AddressResDto getDeliveryAddressById(UUID id) {
+
+        DeliveryAddress deliveryAddress = addressRepository.findByDeliveryAddressIdAndDeletedAtIsNull(id)
+                .orElseThrow(() -> new DeliveryAddressNotFoundException("DeliveryAddress Not Found By Id : "+ id));
+
+        return  deliveryAddress.toResponse();
     }
 }


### PR DESCRIPTION
- /api/delivery-addresses/{id} 경로의 GET 요청을 처리
- DeliveryAddressNotFoundException.java 커스텀 예외처리 구현 404(not found) 반환
- DeliveryAddressRepository 삭제되지 않은 단일 유저 조회 구현
  - findByDeliveryAddressIdAndDeletedAtIsNull