### PR TITLE
<배송자> 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/domain/delivery_address/controller/DeliveryAddressController.java
+++ b/src/main/java/com/sparta/delivery/domain/delivery_address/controller/DeliveryAddressController.java
@@ -66,6 +66,13 @@ public class DeliveryAddressController {
                 .body(deliveryAddressService.updateDeliveryAddresses(id,addressReqDto,principalDetails));
     }
 
+    @PatchMapping("/{id}/delete")
+    public ResponseEntity<?> deleteDeliveryAddresses(@PathVariable("id") UUID id,
+                                                     @AuthenticationPrincipal PrincipalDetails principalDetails){
+        deliveryAddressService.deleteDeliveryAddresses(id,principalDetails);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
     private Map<String, Object> ValidationErrorResponse(BindingResult bindingResult) {
         List<Map<String, String>> errors = bindingResult.getFieldErrors().stream()
                 .map(fieldError -> Map.of(

--- a/src/main/java/com/sparta/delivery/domain/delivery_address/repository/DeliveryAddressRepository.java
+++ b/src/main/java/com/sparta/delivery/domain/delivery_address/repository/DeliveryAddressRepository.java
@@ -11,10 +11,10 @@ import java.util.UUID;
 public interface DeliveryAddressRepository extends JpaRepository<DeliveryAddress , UUID>, QuerydslPredicateExecutor<DeliveryAddress> {
 
     // 해당 유저가 특정 배송지명을 가진 주소를 가지고있는지 여부를 반환
-    boolean existsByUserAndDeliveryAddress(User user, String deliveryAddress);
+    boolean existsByUserAndDeliveryAddressAndDeletedAtIsNull(User user, String deliveryAddress);
 
     // 사용자가 가지고있는 배송지 개수의 수 반환
-    long countByUser(User user);
+    long countByUserAndDeletedAtIsNull(User user);
 
     // 제거 되지않은 배송지 반환
     Optional<DeliveryAddress> findByDeliveryAddressIdAndDeletedAtIsNull(UUID deliveryAddressId);

--- a/src/main/java/com/sparta/delivery/domain/delivery_address/service/DeliveryAddressService.java
+++ b/src/main/java/com/sparta/delivery/domain/delivery_address/service/DeliveryAddressService.java
@@ -37,11 +37,13 @@ public class DeliveryAddressService {
                 .orElseThrow(()-> new IllegalArgumentException("Invalid username : " + principalDetails.getUsername()));
 
         // 동일한 user를 가지고있는 deliveryAddress 중에 중복된 명이 있으면 중복 반환
+        // 삭제된 deliveryAddress 는 중복 검사에서 제외
         if(addressRepository.existsByUserAndDeliveryAddressAndDeletedAtIsNull(user, addressReqDto.getDeliveryAddress())){
             throw new IllegalArgumentException("해당 유저의 동일한 배송지가 이미 존재합니다. :" + addressReqDto.getDeliveryAddress());
         }
 
         // user는 가지고있는 deliveryAddress수가 3개 까지만 가질 수 있음
+        // 삭제된 deliveryAddress 는 count 에서 제외
         if (addressRepository.countByUserAndDeletedAtIsNull(user) >= 3){
             throw new IllegalArgumentException("배송지는 최대 3개 까지만 추가할 수 있습니다.");
         }

--- a/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
@@ -165,6 +165,8 @@ public class UserService {
             builder.and(qUser.role.eq(userSearchReqDto.getRole()));
         }
 
+        builder.and(qUser.deletedAt.isNull());
+
         return builder;
     }
 


### PR DESCRIPTION
- /api/delivery-addresses/{id}/delete 경로의 PATCH 요청을 처리
- 배송지의 소유자 또는 마스터 권한을 가진 사용자만 삭제 가능 (그 외 403 응답)
- 정상 동작이 200 응답 반환
- 삭제처리된 배송지와 같은 이름은 생성 가능
- 삭제처리된 배송지는 count 에서 제외
- UserService 검색 조회에 삭제된 유저제외하는 로직 추가