### PR TITLE
상품 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
@@ -51,6 +51,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(status).body(response);
     }
 
+    @ExceptionHandler(ProductAlreadyDeletedException.class)
+    public ResponseEntity<ExceptionResponse> productAlreadyDeletedException(ProductAlreadyDeletedException ex){
+        int status = HttpServletResponse.SC_CONFLICT;
+        ExceptionResponse response = new ExceptionResponse("CONFLICT", ex.getMessage(), status);
+        return ResponseEntity.status(status).body(response);
+    }
+
     @ExceptionHandler(PaymentAlreadyCompletedException.class)
     public ResponseEntity<ExceptionResponse> PaymentAlreadyCompletedException(PaymentAlreadyCompletedException ex){
         int status = HttpServletResponse.SC_CONFLICT;

--- a/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
@@ -37,6 +37,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(status).body(response);
     }
 
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ExceptionResponse> unauthorizedException(UnauthorizedException ex){
+        int status = HttpServletResponse.SC_UNAUTHORIZED;
+        ExceptionResponse response = new ExceptionResponse("UNAUTHORIZED", ex.getMessage(), status);
+        return ResponseEntity.status(status).body(response);
+    }
+
     @ExceptionHandler(ProductNotFoundException.class)
     public ResponseEntity<ExceptionResponse> productNotFoundException(ProductNotFoundException ex){
         int status = HttpServletResponse.SC_NOT_FOUND;

--- a/src/main/java/com/sparta/delivery/config/global/exception/custom/ProductAlreadyDeletedException.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/custom/ProductAlreadyDeletedException.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.config.global.exception.custom;
+
+public class ProductAlreadyDeletedException extends RuntimeException {
+    public ProductAlreadyDeletedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/delivery/config/global/exception/custom/UnauthorizedException.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/custom/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.config.global.exception.custom;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/delivery/domain/product/controller/ProductController.java
+++ b/src/main/java/com/sparta/delivery/domain/product/controller/ProductController.java
@@ -41,8 +41,8 @@ public class ProductController {
     }
 
     @PatchMapping("/{productId}")
-    public ResponseEntity<ProductResponseDto> updateProduct(@PathVariable UUID productId, @Valid @RequestBody ProductUpdateRequestDto productUpdateRequestDto) {
-        ProductResponseDto productResponseDto = productService.updateProduct(productId, productUpdateRequestDto);
+    public ResponseEntity<ProductResponseDto> updateProduct(@PathVariable UUID productId, @Valid @RequestBody ProductUpdateRequestDto productUpdateRequestDto, @AuthenticationPrincipal PrincipalDetails userDetails) {
+        ProductResponseDto productResponseDto = productService.updateProduct(productId, productUpdateRequestDto, userDetails);
         return ResponseEntity.ok(productResponseDto);
     }
 

--- a/src/main/java/com/sparta/delivery/domain/product/controller/ProductController.java
+++ b/src/main/java/com/sparta/delivery/domain/product/controller/ProductController.java
@@ -7,7 +7,6 @@ import com.sparta.delivery.domain.product.dto.ProductUpdateRequestDto;
 import com.sparta.delivery.domain.product.service.ProductService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.hibernate.annotations.Fetch;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -44,6 +43,12 @@ public class ProductController {
     @PatchMapping("/{productId}")
     public ResponseEntity<ProductResponseDto> updateProduct(@PathVariable UUID productId, @Valid @RequestBody ProductUpdateRequestDto productUpdateRequestDto) {
         ProductResponseDto productResponseDto = productService.updateProduct(productId, productUpdateRequestDto);
+        return ResponseEntity.ok(productResponseDto);
+    }
+
+    @PatchMapping("/{productId}/delete")
+    public ResponseEntity<ProductResponseDto> deleteProduct(@PathVariable UUID productId, @AuthenticationPrincipal PrincipalDetails userDetails) {
+        ProductResponseDto productResponseDto = productService.deleteProduct(productId, userDetails);
         return ResponseEntity.ok(productResponseDto);
     }
 }

--- a/src/main/java/com/sparta/delivery/domain/product/entity/Product.java
+++ b/src/main/java/com/sparta/delivery/domain/product/entity/Product.java
@@ -6,6 +6,7 @@ import com.sparta.delivery.domain.store.entity.Stores;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -45,5 +46,11 @@ public class Product extends Timestamped {
         this.price = (productUpdateRequestDto.getPrice() == 0 || productUpdateRequestDto.getPrice() < 0) ? this.price : productUpdateRequestDto.getPrice();
         this.quantity = productUpdateRequestDto.getQuantity() == 0 ? this.quantity : productUpdateRequestDto.getQuantity();
         this.hidden = productUpdateRequestDto.isHidden();
+    }
+
+    public void softDelete(String username) {
+        this.hidden = true;
+        setDeletedBy(username);
+        setDeletedAt(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/sparta/delivery/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/sparta/delivery/domain/product/repository/ProductRepository.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public interface ProductRepository extends JpaRepository<Product, UUID> {
 
-    boolean existsByNameAndStore_StoreId(String name, UUID storeId);
-
     Page<Product> findAllByOrderByCreatedAtDescUpdatedAtDesc(Pageable pageable);
+
+    boolean existsByNameAndStore_StoreIdAndDeletedAtIsNull(String name, UUID storeId);
 }

--- a/src/main/java/com/sparta/delivery/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/sparta/delivery/domain/product/repository/ProductRepository.java
@@ -1,15 +1,11 @@
 package com.sparta.delivery.domain.product.repository;
 
 import com.sparta.delivery.domain.product.entity.Product;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface ProductRepository extends JpaRepository<Product, UUID> {
-
-    Page<Product> findAllByOrderByCreatedAtDescUpdatedAtDesc(Pageable pageable);
 
     boolean existsByNameAndStore_StoreIdAndDeletedAtIsNull(String name, UUID storeId);
 }

--- a/src/main/java/com/sparta/delivery/domain/product/service/ProductService.java
+++ b/src/main/java/com/sparta/delivery/domain/product/service/ProductService.java
@@ -31,7 +31,7 @@ public class ProductService {
     private static final int DEFAULT_PAGE_SIZE = 10;
 
     public ProductResponseDto addProductToStore(UUID storeId, ProductRequestDto productRequestDto, String username) {
-        if (productRepository.existsByNameAndStore_StoreId(productRequestDto.getName(), storeId)) {
+        if (productRepository.existsByNameAndStore_StoreIdAndDeletedAtIsNull(productRequestDto.getName(), storeId)) {
             throw new DuplicateProductException("이미 동일한 이름의 상품이 존재합니다.");
         }
 


### PR DESCRIPTION
### 작업 내용
- 상품 삭제 기능 구현
- 삭제 권한이 없는 사용자 처리를 위한 'UnauthorizedException' 커스텀 예외 정의
- 이미 삭제된 상품 처리를 위한 'ProductAlreadyDeletedException' 커스텀 예외 정의
- 권한 체크 로직을 재사용 가능한 메서드로 통합
  - 권한 체크 결과를 반환하는 AuthorizationResult 레코드 도입
- 동일한 이름의 상품이 삭제 상태일 경우 등록 가능하도록 수정