### PR TITLE
<보안>  EnableMethodSecurity 활성화 및 JWT 필터/예외 처리 개선

### DIFF
--- a/src/main/java/com/sparta/delivery/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/delivery/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -15,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;

--- a/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
@@ -96,9 +96,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> exception(Exception ex){
-
-        System.out.println("Exception 발생: " + ex.getClass().getSimpleName());
-
         int status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
         ExceptionResponse response = new ExceptionResponse("그 외 모든 에러", ex.getMessage(), status);
         return ResponseEntity.status(status).body(response);

--- a/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.sparta.delivery.config.global.exception;
 import com.sparta.delivery.config.global.exception.custom.*;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -86,8 +87,18 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(status).body(response);
     }
 
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<ExceptionResponse> AuthorizationDeniedException(AuthorizationDeniedException ex){
+        int status = HttpServletResponse.SC_FORBIDDEN;
+        ExceptionResponse response = new ExceptionResponse("Access Denied", ex.getMessage(), status);
+        return ResponseEntity.status(status).body(response);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> exception(Exception ex){
+
+        System.out.println("Exception 발생: " + ex.getClass().getSimpleName());
+
         int status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
         ExceptionResponse response = new ExceptionResponse("그 외 모든 에러", ex.getMessage(), status);
         return ResponseEntity.status(status).body(response);

--- a/src/main/java/com/sparta/delivery/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/delivery/config/jwt/JwtAuthenticationFilter.java
@@ -71,8 +71,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String headerAuthorizationToken = request.getHeader(AUTHORIZATION_HEADER);
 
+        // JWT 토큰이 없거나 Bearer 접두어가 없는 경우
         if (headerAuthorizationToken == null || !headerAuthorizationToken.startsWith(BEARER_PREFIX)){
-            filterChain.doFilter(request,response);
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            PrintWriter writer = response.getWriter();
+            writer.print("No authentication information found. Please log in.");
+            return;
         }
 
         String accessToken = headerAuthorizationToken.split(" ")[1];


### PR DESCRIPTION
- EnableMethodSecurity 를 활성화해 preauthorize, postauthorize 사용가능
- JwtAuthenticationFilter 수정: 토큰이 없거나 Bearer 접두어가 없는 경우 401 응답과 함께 로그인 요청 메시지 반환
  조금 더 유연한 처리
- PreAuthorize 권한 오류(AccessDeniedException)를 처리하기 위한 GlobalExceptionHandler 추가