### PR TITLE
<보안> Access 토큰 재발급 기능 구현 및 JWT 아키텍처 수정

### DIFF
--- a/src/main/java/com/sparta/delivery/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/delivery/config/SecurityConfig.java
@@ -1,8 +1,8 @@
 package com.sparta.delivery.config;
 
 
-import com.sparta.delivery.config.jwt.JwtAuthenticationFilter;
-import com.sparta.delivery.config.jwt.JwtUtil;
+import com.sparta.delivery.config.filter.JwtAuthenticationFilter;
+import com.sparta.delivery.domain.token.service.JwtUtil;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -43,6 +43,7 @@ public class SecurityConfig {
                 authorizationHttpRequest
                         .requestMatchers("/api/user/signup").permitAll() // 회원 가입 및 로그인은 접근 허가
                         .requestMatchers("/api/user/signin").permitAll()
+                        .requestMatchers("/api/token/reissue").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated() // 그 외 모든 요청 인증처리
                 );

--- a/src/main/java/com/sparta/delivery/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/delivery/config/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,8 @@
-package com.sparta.delivery.config.jwt;
+package com.sparta.delivery.config.filter;
 
 import com.sparta.delivery.config.auth.PrincipalDetails;
+import com.sparta.delivery.config.global.exception.custom.InvalidTokenException;
+import com.sparta.delivery.domain.token.service.JwtUtil;
 import com.sparta.delivery.domain.user.entity.User;
 import com.sparta.delivery.domain.user.enums.UserRoles;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -50,6 +52,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final List<String> excludeUrls = List.of(
             "/api/user/signup",
             "/api/user/signin",
+            "/api/token/reissue",
             "/swagger-ui/**",
             "/v3/api-docs/**"
     );
@@ -84,6 +87,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             jwtUtil.isExpired(accessToken);
 
+            if (!jwtUtil.getCategory(accessToken).equals("access")){
+                throw new InvalidTokenException("Invalid token category. Expected 'access' token.");
+            }
+
             String username = jwtUtil.getUsername(accessToken);
             String email = jwtUtil.getEmail(accessToken);
             String role = jwtUtil.getRole(accessToken);
@@ -107,7 +114,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         } catch (ExpiredJwtException e) {
             PrintWriter writer = response.getWriter();
-            writer.print("Access token expired");
+            writer.print("Access token expired 22");
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         } catch (MalformedJwtException e) {

--- a/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
@@ -38,6 +38,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(status).body(response);
     }
 
+    @ExceptionHandler(RefreshTokenAlreadyExistsException.class)
+    public ResponseEntity<ExceptionResponse> RefreshTokenAlreadyExistsException(RefreshTokenAlreadyExistsException ex){
+        int status = HttpServletResponse.SC_CONFLICT;
+        ExceptionResponse response = new ExceptionResponse("CONFLICT", ex.getMessage(), status);
+        return ResponseEntity.status(status).body(response);
+    }
+
     @ExceptionHandler(UnauthorizedException.class)
     public ResponseEntity<ExceptionResponse> unauthorizedException(UnauthorizedException ex){
         int status = HttpServletResponse.SC_UNAUTHORIZED;

--- a/src/main/java/com/sparta/delivery/config/global/exception/custom/InvalidRefreshTokenException.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/custom/InvalidRefreshTokenException.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.config.global.exception.custom;
+
+public class InvalidRefreshTokenException extends RuntimeException{
+    public InvalidRefreshTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/delivery/config/global/exception/custom/InvalidTokenException.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/custom/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.config.global.exception.custom;
+
+public class InvalidTokenException extends RuntimeException{
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/delivery/config/global/exception/custom/RefreshTokenAlreadyExistsException.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/custom/RefreshTokenAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.config.global.exception.custom;
+
+public class RefreshTokenAlreadyExistsException extends RuntimeException{
+    public RefreshTokenAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/delivery/config/jwt/JwtUtil.java
+++ b/src/main/java/com/sparta/delivery/config/jwt/JwtUtil.java
@@ -15,13 +15,12 @@ import java.util.Date;
 public class JwtUtil {
 
     private final SecretKey secretKey;
-    private final Long expiredMs;
 
-    public JwtUtil(@Value("${spring.jwt.secret}") String secretKey,
-                   @Value("${spring.jwt.validityInMilliseconds}") Long expiredMs) {
+
+    public JwtUtil(@Value("${spring.jwt.secret}") String secretKey) {
         this.secretKey = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8),
                 Jwts.SIG.HS256.key().build().getAlgorithm());
-        this.expiredMs = expiredMs;
+
     }
 
     public String getUsername(String token){
@@ -39,14 +38,23 @@ public class JwtUtil {
         return claims.get("email",String.class);
     }
 
+    //토큰 판단용
+    public String getCategory(String token){
+        Claims claims = parseClaims(token);
+        return claims.get("category",String.class);
+    }
+
     public boolean isExpired(String token) {
         Claims claims = parseClaims(token); // Claims 파싱
         return claims.getExpiration().before(new Date()); // 만료 체크
     }
 
 
-    public String createJwt(String username, String email ,UserRoles role){
+
+
+    public String createJwt(String category , String username, String email ,UserRoles role, Long expiredMs){
         return Jwts.builder()
+                .claim("category",category)
                 .claim("username",username)
                 .claim("email",email)
                 .claim("role",role.name())

--- a/src/main/java/com/sparta/delivery/domain/token/controller/JwtController.java
+++ b/src/main/java/com/sparta/delivery/domain/token/controller/JwtController.java
@@ -1,0 +1,29 @@
+package com.sparta.delivery.domain.token.controller;
+
+import com.sparta.delivery.domain.token.service.RefreshTokenServiceImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/token")
+@RequiredArgsConstructor
+public class JwtController {
+
+    private final RefreshTokenServiceImpl refreshTokenService;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissueAccessToken(@CookieValue(name = "refresh", defaultValue = "")String refreshToken){
+
+        String newAccessToken = refreshTokenService.reissueAccessToken(refreshToken);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header("Authorization", newAccessToken)
+                .build();
+    }
+
+}

--- a/src/main/java/com/sparta/delivery/domain/token/entity/RefreshToken.java
+++ b/src/main/java/com/sparta/delivery/domain/token/entity/RefreshToken.java
@@ -1,0 +1,37 @@
+package com.sparta.delivery.domain.token.entity;
+
+import com.sparta.delivery.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "p_refresh_token")
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID RefreshTokenId;
+
+    // 토큰의 주인 유저
+    // 각 유저 당 하나의 리프레쉬 토큰만 가짐
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true, nullable = false)
+    private User user;
+
+    // refresh 토큰 키 값
+    @Column(nullable = false , length = 512)
+    private String refresh;
+
+    // refresh 토큰 유효시간
+    @Column(nullable = false)
+    private String expiration;
+}

--- a/src/main/java/com/sparta/delivery/domain/token/interfaces/JwtService.java
+++ b/src/main/java/com/sparta/delivery/domain/token/interfaces/JwtService.java
@@ -1,0 +1,14 @@
+package com.sparta.delivery.domain.token.interfaces;
+
+import com.sparta.delivery.domain.user.entity.User;
+
+public interface JwtService {
+
+    String createAccessToken(User user);
+
+    String createRefreshToken(User user);
+
+    boolean isTokenExpired(String token);
+
+    String getCategory(String token);
+}

--- a/src/main/java/com/sparta/delivery/domain/token/interfaces/RefreshTokenService.java
+++ b/src/main/java/com/sparta/delivery/domain/token/interfaces/RefreshTokenService.java
@@ -1,0 +1,12 @@
+package com.sparta.delivery.domain.token.interfaces;
+
+import com.sparta.delivery.domain.user.entity.User;
+
+public interface RefreshTokenService {
+
+    void addRefreshTokenEntity(User user , String refreshToken);
+
+    void removeRefreshToken(String refreshToken);
+
+    String reissueAccessToken(String refreshToken);
+}

--- a/src/main/java/com/sparta/delivery/domain/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sparta/delivery/domain/token/repository/RefreshTokenRepository.java
@@ -1,9 +1,20 @@
 package com.sparta.delivery.domain.token.repository;
 
 import com.sparta.delivery.domain.token.entity.RefreshToken;
+import com.sparta.delivery.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken , UUID> {
+
+    Optional<RefreshToken> findByUser(User user);
+
+    Optional<RefreshToken> findByRefresh(String refresh);
+
+    Boolean existsByRefresh(String refresh);
+
+    void deleteByRefresh(String refresh);
+
 }

--- a/src/main/java/com/sparta/delivery/domain/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sparta/delivery/domain/token/repository/RefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.delivery.domain.token.repository;
+
+import com.sparta.delivery.domain.token.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken , UUID> {
+}

--- a/src/main/java/com/sparta/delivery/domain/token/service/JwtServiceImpl.java
+++ b/src/main/java/com/sparta/delivery/domain/token/service/JwtServiceImpl.java
@@ -1,0 +1,50 @@
+package com.sparta.delivery.domain.token.service;
+
+import com.sparta.delivery.domain.token.interfaces.JwtService;
+import com.sparta.delivery.domain.user.entity.User;
+import io.jsonwebtoken.ExpiredJwtException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtServiceImpl implements JwtService {
+
+    private final JwtUtil jwtUtil;
+
+    private final Long accessExpiredMs;
+    private final Long refreshExpiredMs;
+
+    public JwtServiceImpl(JwtUtil jwtUtil,
+                          @Value("${spring.jwt.accessTokenValidityInMilliseconds}") Long accessExpiredMs,
+                          @Value("${spring.jwt.refreshTokenValidityInMilliseconds}") Long refreshExpiredMs) {
+        this.jwtUtil = jwtUtil;
+        this.accessExpiredMs = accessExpiredMs;
+        this.refreshExpiredMs = refreshExpiredMs;
+    }
+
+    @Override
+    public String createAccessToken(User user) {
+        return jwtUtil.createJwt("access",user.getUsername(), user.getEmail(), user.getRole(),accessExpiredMs);
+    }
+
+    @Override
+    public String createRefreshToken(User user) {
+        return jwtUtil.createJwt("refresh",user.getUsername(), user.getEmail(), user.getRole(),refreshExpiredMs);
+    }
+
+    @Override
+    public boolean isTokenExpired(String token) {
+
+        try{
+            jwtUtil.isExpired(token);
+            return false;
+        }catch (ExpiredJwtException e){
+            return true;
+        }
+    }
+
+    @Override
+    public String getCategory(String token) {
+        return jwtUtil.getCategory(token);
+    }
+}

--- a/src/main/java/com/sparta/delivery/domain/token/service/JwtUtil.java
+++ b/src/main/java/com/sparta/delivery/domain/token/service/JwtUtil.java
@@ -46,7 +46,7 @@ public class JwtUtil {
 
     public boolean isExpired(String token) {
         Claims claims = parseClaims(token); // Claims 파싱
-        return claims.getExpiration().before(new Date()); // 만료 체크
+        return claims.getExpiration().before(new Date()); // 만료 체크, 만료 시 true
     }
 
 

--- a/src/main/java/com/sparta/delivery/domain/token/service/JwtUtil.java
+++ b/src/main/java/com/sparta/delivery/domain/token/service/JwtUtil.java
@@ -1,4 +1,4 @@
-package com.sparta.delivery.config.jwt;
+package com.sparta.delivery.domain.token.service;
 
 import com.sparta.delivery.domain.user.enums.UserRoles;
 import io.jsonwebtoken.Claims;

--- a/src/main/java/com/sparta/delivery/domain/token/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/sparta/delivery/domain/token/service/RefreshTokenServiceImpl.java
@@ -1,0 +1,86 @@
+package com.sparta.delivery.domain.token.service;
+
+import com.sparta.delivery.config.global.exception.custom.InvalidRefreshTokenException;
+import com.sparta.delivery.config.global.exception.custom.RefreshTokenAlreadyExistsException;
+import com.sparta.delivery.domain.token.entity.RefreshToken;
+import com.sparta.delivery.domain.token.interfaces.RefreshTokenService;
+import com.sparta.delivery.domain.token.repository.RefreshTokenRepository;
+import com.sparta.delivery.domain.user.entity.User;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+public class RefreshTokenServiceImpl implements RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final JwtUtil jwtUtil;
+    private final Long accessExpiredMs;
+    private final Long refreshExpiredMs;
+
+    public RefreshTokenServiceImpl(RefreshTokenRepository refreshTokenRepository,
+                                   JwtUtil jwtUtil,
+                                   @Value("${spring.jwt.accessTokenValidityInMilliseconds}") Long accessExpiredMs,
+                                   @Value("${spring.jwt.refreshTokenValidityInMilliseconds}") Long refreshExpiredMs) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.jwtUtil = jwtUtil;
+        this.accessExpiredMs = accessExpiredMs;
+        this.refreshExpiredMs = refreshExpiredMs;
+    }
+
+
+    @Override
+    public void addRefreshTokenEntity(User user, String refresh) {
+        if (refreshTokenRepository.findByUser(user).isPresent()){
+            throw new RefreshTokenAlreadyExistsException("이미 로그인되었거나 비정상 로그아웃되었습니다.");
+        }
+
+        Date date = new Date(System.currentTimeMillis() + refreshExpiredMs);
+
+        RefreshToken refreshToken = RefreshToken.builder()
+                .user(user)
+                .refresh(refresh)
+                .expiration(date.toString())
+                .build();
+
+        refreshTokenRepository.save(refreshToken);
+    }
+
+
+    @Override
+    public void removeRefreshToken(String refreshToken) {
+        if(!refreshTokenRepository.existsByRefresh(refreshToken)){
+            throw new InvalidRefreshTokenException("등록된 토큰이 아닙니다.");
+        }
+
+        refreshTokenRepository.deleteByRefresh(refreshToken);
+
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+    }
+    // 1. 재발급 요청은 프론트에서 보낸다
+
+    @Override
+    public String reissueAccessToken(String refreshToken) {
+
+        if (jwtUtil.isExpired(refreshToken)){
+            throw new ExpiredJwtException(null, null, "Refresh token is still valid, no need to reissue access token");
+        }
+
+        if (!jwtUtil.getCategory(refreshToken).equals("refresh")){
+            throw new InvalidRefreshTokenException("Provided token is not a refresh token");
+        }
+
+        RefreshToken token = refreshTokenRepository.findByRefresh(refreshToken)
+                .orElseThrow(() -> new InvalidRefreshTokenException("Invalid or non-existent refresh token"));
+
+        User user = token.getUser();
+
+        return jwtUtil.createJwt("access",user.getUsername(),user.getEmail(),user.getRole(),accessExpiredMs);
+    }
+}

--- a/src/main/java/com/sparta/delivery/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/delivery/domain/user/controller/UserController.java
@@ -58,6 +58,20 @@ public class UserController {
                 .build();
     }
 
+    @PostMapping("/logout")
+    public ResponseEntity<?> removeRefreshToken(@CookieValue(name = "refresh", defaultValue = "")String refreshToken){
+
+        if (refreshToken.isEmpty()){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body("Refresh token not found in cookies");
+        }
+
+        userService.removeRefreshToken(refreshToken);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .build();
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<?> getUserById(@PathVariable("id")UUID id){
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/sparta/delivery/domain/user/dto/JwtResponseDto.java
+++ b/src/main/java/com/sparta/delivery/domain/user/dto/JwtResponseDto.java
@@ -9,4 +9,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class JwtResponseDto {
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/com/sparta/delivery/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/delivery/domain/user/entity/User.java
@@ -41,11 +41,9 @@ public class User extends Timestamped {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<DeliveryAddress> deliveryAddresses = new ArrayList<>();
 
-
     public void addDeliveryAddress(DeliveryAddress deliveryAddress){
         this.deliveryAddresses.add(deliveryAddress);
     }
-
 
     public UserResDto toResponseDto() {
 

--- a/src/main/java/com/sparta/delivery/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/delivery/domain/user/repository/UserRepository.java
@@ -1,10 +1,7 @@
 package com.sparta.delivery.domain.user.repository;
 
 import com.sparta.delivery.domain.user.entity.User;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
 import java.util.Optional;
@@ -22,8 +19,4 @@ public interface UserRepository extends JpaRepository<User , UUID> , QuerydslPre
 
     // 삭제되지 않은 유저 단일 조회 (username)
     Optional<User> findByUsernameAndDeletedAtIsNull(String username);
-
-    // 삭제되지 않은 유저 페이징 조회 (생성일 최근일 부터 정렬)
-    @Query("SELECT u FROM User u WHERE u.deletedAt IS NULL ORDER BY u.createdAt DESC")
-    Page<User> findAllDeletedIsNull(Pageable pageable);
 }

--- a/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
@@ -3,16 +3,17 @@ package com.sparta.delivery.domain.user.service;
 import com.querydsl.core.BooleanBuilder;
 import com.sparta.delivery.config.auth.PrincipalDetails;
 import com.sparta.delivery.config.global.exception.custom.ForbiddenException;
+import com.sparta.delivery.config.global.exception.custom.InvalidRefreshTokenException;
 import com.sparta.delivery.config.global.exception.custom.UserNotFoundException;
-import com.sparta.delivery.config.jwt.JwtUtil;
-import com.sparta.delivery.domain.token.entity.RefreshToken;
 import com.sparta.delivery.domain.token.repository.RefreshTokenRepository;
+import com.sparta.delivery.domain.token.service.JwtServiceImpl;
+import com.sparta.delivery.domain.token.service.RefreshTokenServiceImpl;
 import com.sparta.delivery.domain.user.dto.*;
 import com.sparta.delivery.domain.user.entity.QUser;
 import com.sparta.delivery.domain.user.entity.User;
 import com.sparta.delivery.domain.user.enums.UserRoles;
 import com.sparta.delivery.domain.user.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -21,33 +22,19 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.UUID;
 
 @Service
+@RequiredArgsConstructor
 @Transactional
 public class UserService {
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder  passwordEncoder;
-    private final JwtUtil jwtUtil;
+    private final JwtServiceImpl jwtService;
+    private final RefreshTokenServiceImpl refreshTokenService;
 
-    private final Long accessExpiredMs;
-    private final Long refreshExpiredMs;
-
-    public UserService(UserRepository userRepository, RefreshTokenRepository refreshTokenRepository,
-                       PasswordEncoder passwordEncoder,
-                       JwtUtil jwtUtil,
-                       @Value("${spring.jwt.accessTokenValidityInMilliseconds}") Long accessExpiredMs,
-                       @Value("${spring.jwt.refreshTokenValidityInMilliseconds}") Long refreshExpiredMs) {
-        this.userRepository = userRepository;
-        this.refreshTokenRepository = refreshTokenRepository;
-        this.passwordEncoder = passwordEncoder;
-        this.jwtUtil = jwtUtil;
-        this.accessExpiredMs = accessExpiredMs;
-        this.refreshExpiredMs = refreshExpiredMs;
-    }
 
     public UserResDto signup(SignupReqDto signupReqDto) {
 
@@ -77,12 +64,25 @@ public class UserService {
             throw new IllegalArgumentException("Invalid password : " + loginRequestDto.getPassword());
         }
 
-        String accessToken = jwtUtil.createJwt("access",user.getUsername(), user.getEmail(), user.getRole(),accessExpiredMs);
-        String refreshToken = jwtUtil.createJwt("refresh",user.getUsername(), user.getEmail(), user.getRole(),refreshExpiredMs);
+        String accessToken = jwtService.createAccessToken(user);
+        String refreshToken = jwtService.createRefreshToken(user);
 
-        addRefreshTokenEntity(user,refreshToken);
+        refreshTokenService.addRefreshTokenEntity(user,refreshToken);
 
         return new JwtResponseDto(accessToken,refreshToken);
+    }
+
+    public void removeRefreshToken(String refreshToken) {
+
+        if (jwtService.isTokenExpired(refreshToken)){
+            return;
+        }
+
+        if (!jwtService.getCategory(refreshToken).equals("refresh")){
+            throw new InvalidRefreshTokenException("잘못된 토큰이 들어왔습니다.");
+        }
+
+        refreshTokenService.removeRefreshToken(refreshToken);
     }
 
     @Transactional(readOnly = true)
@@ -168,18 +168,6 @@ public class UserService {
     }
 
 
-    private void addRefreshTokenEntity(User user, String refresh){
-
-        Date date = new Date(System.currentTimeMillis() + refreshExpiredMs);
-
-        RefreshToken refreshToken = RefreshToken.builder()
-                .user(user)
-                .refresh(refresh)
-                .expiration(date.toString())
-                .build();
-
-        refreshTokenRepository.save(refreshToken);
-    }
 
 
     private BooleanBuilder buildSearchConditions(UserSearchReqDto userSearchReqDto, QUser qUser) {
@@ -230,4 +218,6 @@ public class UserService {
             return sort.ascending();
         }
     }
+
+
 }

--- a/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/delivery/domain/user/service/UserService.java
@@ -5,7 +5,6 @@ import com.sparta.delivery.config.auth.PrincipalDetails;
 import com.sparta.delivery.config.global.exception.custom.ForbiddenException;
 import com.sparta.delivery.config.global.exception.custom.InvalidRefreshTokenException;
 import com.sparta.delivery.config.global.exception.custom.UserNotFoundException;
-import com.sparta.delivery.domain.token.repository.RefreshTokenRepository;
 import com.sparta.delivery.domain.token.service.JwtServiceImpl;
 import com.sparta.delivery.domain.token.service.RefreshTokenServiceImpl;
 import com.sparta.delivery.domain.user.dto.*;
@@ -30,7 +29,6 @@ import java.util.UUID;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder  passwordEncoder;
     private final JwtServiceImpl jwtService;
     private final RefreshTokenServiceImpl refreshTokenService;

--- a/src/test/java/com/sparta/delivery/userTest/UserServiceTest.java
+++ b/src/test/java/com/sparta/delivery/userTest/UserServiceTest.java
@@ -5,7 +5,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.sparta.delivery.config.auth.PrincipalDetails;
 import com.sparta.delivery.config.global.exception.custom.ForbiddenException;
 import com.sparta.delivery.config.global.exception.custom.UserNotFoundException;
-import com.sparta.delivery.config.jwt.JwtUtil;
+import com.sparta.delivery.domain.token.service.JwtUtil;
 import com.sparta.delivery.domain.user.dto.*;
 import com.sparta.delivery.domain.user.entity.User;
 import com.sparta.delivery.domain.user.enums.UserRoles;
@@ -117,7 +117,7 @@ public class UserServiceTest {
 
         when(userRepository.findByUsernameAndDeletedAtIsNull("newuser")).thenReturn(Optional.of(newUser));
         when(passwordEncoder.matches("password", newUser.getPassword())).thenReturn(true);
-        when(jwtUtil.createJwt(anyString(), anyString(), any(UserRoles.class))).thenReturn("accessToken");
+        when(jwtUtil.createJwt(anyString(), anyString(), anyString(), any(UserRoles.class),1000L)).thenReturn("accessToken");
 
         // When
         JwtResponseDto response = userService.authenticateUser(loginRequestDto);


### PR DESCRIPTION
- /api/token/reissue 경로의 POST 요청을 처리하여 Access 토큰 재발급
- Refresh 토큰 유효성 검사 후 새로운 Access 토큰을 헤더에 포함해 반환

- 기존 JWT 아키텍처 수정 및 헥사고날 아키텍처 도입
  - JwtService, RefreshTokenService를 인터페이스(Port)로 분리하여 의존성 역전 적용
  - JwtServiceImpl, RefreshTokenServiceImpl을 어댑터(Adapter)로 구현하여 인터페이스 기반으로 변경
  - UserService에서 JwtUtil이 아닌 JwtService 인터페이스를 주입받도록 수정