### PR TITLE
상품 설명 문구 추천 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 
 ### YAML ###
 *.yml
+
+### env ###
+.env

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,11 @@ clean.doLast {
 
 
 dependencies {
+    implementation('io.github.cdimascio:java-dotenv:5.2.2')
+
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.100.Final:osx-aarch_64'
+
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/GlobalExceptionHandler.java
@@ -129,6 +129,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(status).body(response);
     }
 
+    @ExceptionHandler(InvalidApiResponseException.class)
+    public ResponseEntity<ExceptionResponse> InvalidApiResponseException(InvalidApiResponseException ex){
+        int status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+        ExceptionResponse response = new ExceptionResponse("INVALID_API_RESPONSE", ex.getMessage(), status);
+        return ResponseEntity.status(status).body(response);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> exception(Exception ex) {
         int status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;

--- a/src/main/java/com/sparta/delivery/config/global/exception/custom/InvalidApiResponseException.java
+++ b/src/main/java/com/sparta/delivery/config/global/exception/custom/InvalidApiResponseException.java
@@ -1,0 +1,7 @@
+package com.sparta.delivery.config.global.exception.custom;
+
+public class InvalidApiResponseException extends RuntimeException {
+    public InvalidApiResponseException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/delivery/domain/ai/controller/AiController.java
+++ b/src/main/java/com/sparta/delivery/domain/ai/controller/AiController.java
@@ -1,0 +1,24 @@
+package com.sparta.delivery.domain.ai.controller;
+
+import com.sparta.delivery.domain.ai.dto.AiRequestDto;
+import com.sparta.delivery.domain.ai.dto.AiResponseDto;
+import com.sparta.delivery.domain.ai.service.AiService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/ai")
+public class AiController {
+
+    private final AiService aiService;
+
+    @GetMapping()
+    public ResponseEntity<AiResponseDto> recommendText(@Valid @RequestBody AiRequestDto requestDto) {
+        AiResponseDto aiResponseDto = aiService.recommendText(requestDto);
+        return ResponseEntity.ok(aiResponseDto);
+    }
+}

--- a/src/main/java/com/sparta/delivery/domain/ai/dto/AiRequestDto.java
+++ b/src/main/java/com/sparta/delivery/domain/ai/dto/AiRequestDto.java
@@ -1,0 +1,19 @@
+package com.sparta.delivery.domain.ai.dto;
+
+import com.sparta.delivery.domain.ai.entity.AiInfo;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class AiRequestDto {
+
+    @Size(max = 150, message = "질문은 150자 이내로 입력 가능합니다.")
+    private String question;
+
+    public AiInfo toEntity(String answer) {
+        return AiInfo.builder()
+                .question(this.question)
+                .answer(answer)
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/delivery/domain/ai/dto/AiResponseDto.java
+++ b/src/main/java/com/sparta/delivery/domain/ai/dto/AiResponseDto.java
@@ -1,0 +1,11 @@
+package com.sparta.delivery.domain.ai.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AiResponseDto {
+
+    private String answer;
+}

--- a/src/main/java/com/sparta/delivery/domain/ai/entity/AiInfo.java
+++ b/src/main/java/com/sparta/delivery/domain/ai/entity/AiInfo.java
@@ -1,0 +1,28 @@
+package com.sparta.delivery.domain.ai.entity;
+
+import com.sparta.delivery.domain.common.Timestamped;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "p_ai_info")
+public class AiInfo extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID aiId;
+
+    @Column(nullable = false)
+    private String question;
+
+    @Column(nullable = false)
+    private String answer;
+}

--- a/src/main/java/com/sparta/delivery/domain/ai/repository/AiRepository.java
+++ b/src/main/java/com/sparta/delivery/domain/ai/repository/AiRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.delivery.domain.ai.repository;
+
+import com.sparta.delivery.domain.ai.entity.AiInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface AiRepository extends JpaRepository<AiInfo, UUID> {
+
+}

--- a/src/main/java/com/sparta/delivery/domain/ai/service/AiService.java
+++ b/src/main/java/com/sparta/delivery/domain/ai/service/AiService.java
@@ -1,0 +1,89 @@
+package com.sparta.delivery.domain.ai.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sparta.delivery.config.global.exception.custom.InvalidApiResponseException;
+import com.sparta.delivery.domain.ai.dto.AiRequestDto;
+import com.sparta.delivery.domain.ai.dto.AiResponseDto;
+import com.sparta.delivery.domain.ai.entity.AiInfo;
+import com.sparta.delivery.domain.ai.repository.AiRepository;
+import io.github.cdimascio.dotenv.Dotenv;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+@Service
+public class AiService {
+
+    private final AiRepository aiRepository;
+    private final WebClient webClient;
+    private static final String API_KEY = Dotenv.load().get("AI_API_KEY");
+    private static final String BASE_URL = "https://generativelanguage.googleapis.com";
+    private static final String CONSTRAINT = "답변을 최대한 간결하게 50자 이하로";
+
+    public AiService(AiRepository aiRepository, WebClient.Builder webClientBuilder) {
+        this.aiRepository = aiRepository;
+        this.webClient = webClientBuilder.baseUrl(BASE_URL).build();
+    }
+
+    public AiResponseDto recommendText(AiRequestDto aiRequestDto) {
+        String userQuestion = aiRequestDto.getQuestion();
+        String questionWithConstraints = userQuestion + CONSTRAINT;
+
+        // AI API 요청 바디
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("contents", List.of(Map.of("parts", List.of(Map.of("text", questionWithConstraints)))));
+
+        CompletableFuture<AiResponseDto> completableFuture = webClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/v1beta/models/gemini-1.5-flash:generateContent")
+                        .queryParam("key", API_KEY)
+                        .build())
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(JsonNode.class) // JSON 전체를 받아서 처리
+                .map(this::extractText)
+                .toFuture();
+
+        try {
+            AiResponseDto completedAiResponseDto = completableFuture.get();
+            AiInfo aiInfo = aiRequestDto.toEntity(completedAiResponseDto.getAnswer());
+            aiRepository.save(aiInfo);
+            return completedAiResponseDto;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("AI API 호출 비동기 작업을 기다리는 동안 스레드가 인터럽트로 인해 중단되었습니다.", e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException("AI API 호출 비동기 작업 실행 중 알 수 없는 오류가 발생했습니다.", e);
+        }
+    }
+
+    private AiResponseDto extractText(JsonNode jsonNode) {
+        try {
+            // 응답 구조: candidates[0] → content → parts[0] → text
+            JsonNode textNode = jsonNode
+                    .path("candidates")
+                    .path(0)
+                    .path("content")
+                    .path("parts")
+                    .path(0)
+                    .path("text");
+
+            if (textNode.isMissingNode() || textNode.asText().isEmpty()) {
+                throw new InvalidApiResponseException("AI API 응답에서 text 필드의 값을 찾을 수 없습니다.");
+            }
+            return new AiResponseDto(textNode.asText());
+        } catch (Exception e) {
+            throw new RuntimeException("응답 파싱 중 알 수 없는 오류가 발생했습니다.");
+        }
+    }
+}


### PR DESCRIPTION
### 작업 내용
- 상품 설명 문구 추천 기능 구현
  - HTTP 요청 처리 도구 중 WebClient를 사용하여 Gemini API와 통신
  - 입력 텍스트 글자수 150자로 제한
  - 요청 텍스트 끝에 "답변을 최대한 간결하게 50자 이하로" 문구를 추가하여 API 사용량 최적화
- WebClient 사용을 위한 webflux 라이브러리 추가
- API Key 관리를 위한 dotenv 라이브러리 추가