### PR TITLE
<유저> UserService CUD 기능에 대한 AOP 기반 로깅 기능 추가

### DIFF
--- a/src/main/java/com/sparta/delivery/domain/user/aop/UserServiceLoggingAspect.java
+++ b/src/main/java/com/sparta/delivery/domain/user/aop/UserServiceLoggingAspect.java
@@ -45,8 +45,12 @@ public class UserServiceLoggingAspect {
             // 실제 메서드 실행
             returnObj = joinPoint.proceed();
 
-            log.info("[UserService] return type = {}", returnObj.getClass().getSimpleName());
-            log.info("[UserService] return value = {}", returnObj);
+            if (returnObj != null) {
+                log.info("[UserService] return type = {}", returnObj.getClass().getSimpleName());
+                log.info("[UserService] return value = {}", returnObj);
+            } else {
+                log.info("[UserService] return value is null");
+            }
         }catch (Exception e){
             log.error("[UserService] Exception occurred during method execution: {} | Error message: {}", method, e.getMessage());
 

--- a/src/main/java/com/sparta/delivery/domain/user/aop/UserServiceLoggingAspect.java
+++ b/src/main/java/com/sparta/delivery/domain/user/aop/UserServiceLoggingAspect.java
@@ -1,0 +1,67 @@
+package com.sparta.delivery.domain.user.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@Aspect
+@Component
+public class UserServiceLoggingAspect {
+
+
+    // UserService 에서 조회 기능(R)을 제외한 메서드(CUD)에 대한 Point 설정
+    // 디비의 변경이 생길 때 마다 로깅확인용
+    @Pointcut("execution(* com.sparta.delivery.domain.user.service.UserService.*(..)) && " +
+            "!execution(* com.sparta.delivery.domain.user.service.UserService.get*(..))")
+    public void userServiceCUDMethods(){}
+
+    @Around("userServiceCUDMethods()")
+    public Object logAfterReturning(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        // 실행된 메서드 정보를 가져옴
+        Method method = getMethod(joinPoint);
+        log.info("===== method name = {} =====", method.getName());
+
+        // 파라미터 가져오기
+        Object[] args = joinPoint.getArgs();
+
+        if (args.length == 0) log.info("no parameter");
+
+        for(Object arg : args){
+            log.info("parameter type = {}",arg.getClass().getSimpleName());
+            log.info("parameter value = {}", arg);
+        }
+
+
+        Object returnObj;
+        try{
+            // 실제 메서드 실행
+            returnObj = joinPoint.proceed();
+
+            log.info("[UserService] return type = {}", returnObj.getClass().getSimpleName());
+            log.info("[UserService] return value = {}", returnObj);
+        }catch (Exception e){
+            log.error("[UserService] Exception occurred during method execution: {} | Error message: {}", method, e.getMessage());
+
+            throw e;
+        }
+
+        return returnObj;
+    }
+
+    private Method getMethod(ProceedingJoinPoint proceedingJoinPoint){
+        MethodSignature signature = (MethodSignature) proceedingJoinPoint.getSignature();
+        return signature.getMethod();
+    }
+
+
+}
+
+

--- a/src/main/java/com/sparta/delivery/domain/user/dto/SignupReqDto.java
+++ b/src/main/java/com/sparta/delivery/domain/user/dto/SignupReqDto.java
@@ -6,8 +6,10 @@ import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor
 public class SignupReqDto {

--- a/src/main/java/com/sparta/delivery/domain/user/dto/UserResDto.java
+++ b/src/main/java/com/sparta/delivery/domain/user/dto/UserResDto.java
@@ -3,10 +3,12 @@ package com.sparta.delivery.domain.user.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.UUID;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserResDto {

--- a/src/main/java/com/sparta/delivery/domain/user/dto/UserRoleUpdateReqDto.java
+++ b/src/main/java/com/sparta/delivery/domain/user/dto/UserRoleUpdateReqDto.java
@@ -5,8 +5,10 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserRoleUpdateReqDto {

--- a/src/main/java/com/sparta/delivery/domain/user/dto/UserSearchReqDto.java
+++ b/src/main/java/com/sparta/delivery/domain/user/dto/UserSearchReqDto.java
@@ -1,13 +1,11 @@
 package com.sparta.delivery.domain.user.dto;
 
 import com.sparta.delivery.domain.user.enums.UserRoles;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserSearchReqDto {

--- a/src/main/java/com/sparta/delivery/domain/user/dto/UserUpdateReqDto.java
+++ b/src/main/java/com/sparta/delivery/domain/user/dto/UserUpdateReqDto.java
@@ -6,8 +6,10 @@ import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
+@ToString
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserUpdateReqDto {


### PR DESCRIPTION
feat : UserService CUD 기능에 대한 AOP 기반 로깅 기능 추가
- UserService의 생성, 수정, 삭제 메서드에 대한 메서드명, 파라미터 타입/값, 반환 값 로깅기능 구현
- Read 기능은 로깅 대상에서 제외 (DB의 변동사항만 로깅)
- 예외 발생시 에러메시지를 포함한 로깅 처리 추가
- p_user 테이블의 변동사항만 파악하기위해 Read 기능은 로깅에서 제외